### PR TITLE
Fix /stickeradd command failing half the time

### DIFF
--- a/app/server/skychat/Server.ts
+++ b/app/server/skychat/Server.ts
@@ -27,7 +27,7 @@ type EventsDescription = {
  */
 export class Server {
 
-    public static readonly UPLOADED_FILE_REGEXP: RegExp = new RegExp(Config.LOCATION + '/uploads/([-\\/._a-zA-Z0-9]+)', 'g');
+    public static readonly UPLOADED_FILE_REGEXP: RegExp = new RegExp(Config.LOCATION + '/uploads/([-\\/._a-zA-Z0-9]+)');
 
     /**
      * List of accepted events.


### PR DESCRIPTION
With the "g" flag, the regex tracks where the last match was found. When you try and match again, since it is a global regex and isn't recreated, it tries to continue matching from there. Since it doesn't match, the match index resets. That's why the command failed half the time.

Removing the "g" flag fixes it.

More info : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky