### PR TITLE
Change halo colors & Introduce log fuzzer plugin & improve overall styling

### DIFF
--- a/app/client/css/abstract/util.scss
+++ b/app/client/css/abstract/util.scss
@@ -12,56 +12,19 @@
     margin: 0 !important;
 }
 
-.mt-1 {
-    margin-top: 10px;
-}
+@for $i from 1 through 10 {
 
-.mt-2 {
-    margin-top: 20px;
-}
+    .mt-#{$i} { margin-top: $i * 10px; }
+    .pt-#{$i} { padding-top: $i * 10px; }
 
-.mt-3 {
-    margin-top: 30px;
-}
+    .mb-#{$i} { margin-bottom: $i * 10px; }
+    .pb-#{$i} { padding-bottom: $i * 10px; }
 
-.mt-4 {
-    margin-top: 40px;
-}
+    .mr-#{$i} { margin-right: $i * 10px; }
+    .pr-#{$i} { padding-right: $i * 10px; }
 
-.mt-5 {
-    margin-top: 50px;
-}
-
-.mt-6 {
-    margin-top: 60px;
-}
-
-.mt-7 {
-    margin-top: 70px;
-}
-
-.mt-8 {
-    margin-top: 80px;
-}
-
-.mt-9 {
-    margin-top: 90px;
-}
-
-.mt-10 {
-    margin-top: 100px;
-}
-
-.mb-3 {
-    margin-bottom: 30px;
-}
-
-.mb-6 {
-    margin-bottom: 60px;
-}
-
-.mb-10 {
-    margin-bottom: 100px;
+    .ml-#{$i} { margin-left: $i * 10px; }
+    .pl-#{$i} { padding-left: $i * 10px; }
 }
 
 .mlzero {

--- a/app/client/src/components/ConnectedUser.vue
+++ b/app/client/src/components/ConnectedUser.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="connected-session"
-         :style="{'border-left-color': session.user.data.plugins.color.main}"
+         :style="{'border-left-color': session.user.data.plugins.color}"
          :class="{
             'selected': isChanSelected(session.user.username),
             'has-unread': getUnreadCount(session.user.username) > 0
@@ -9,13 +9,13 @@
             <span class="rank">
                 <img title="User rank" :src="'/assets/images/' + session.user.rank">
             </span>
-            <div class="image-bubble" :style="{'box-shadow': '0 0 4px 4px ' + session.user.data.plugins.color.secondary}">
+            <div class="image-bubble" :style="{'box-shadow': session.user.data.plugins.halo ? '0 0 4px 4px ' + session.user.data.plugins.color : 'unset'}">
                 <img :src="session.user.data.plugins.avatar">
             </div>
         </div>
         <div class="info">
             <div class="session"
-                 :style="{'color': session.user.data.plugins.color.main}">
+                 :style="{'color': session.user.data.plugins.color}">
                 <i v-show="session.user.data.plugins.pinnedicon" class="pinned-icon material-icons md-14">{{session.user.data.plugins.pinnedicon}}</i>
                 {{session.user.username}}
                 <sup v-show="session.connectionCount > 1">

--- a/app/client/src/components/LeftColumn.vue
+++ b/app/client/src/components/LeftColumn.vue
@@ -1,0 +1,92 @@
+<template>
+    <div class="messages">
+
+        <!-- player -->
+        <player v-if="! hidePlayer" class="player" v-show="playerState && playerState.enabled"/>
+
+        <!-- message feeds -->
+        <messages v-show="! privateMessageChannel" :messages="messages" @select-message="onSelectMessage" class="scrollbar" />
+        <messages v-show="privateMessageChannel" :messages="privateMessages" @select-message="onSelectMessage" class="scrollbar" />
+
+        <!-- typing list -->         
+        <typing-list id="typing-list" />
+
+        <!-- new message form -->
+        <message-form ref="messageForm" id="message-form"/>
+    </div>
+</template>
+
+<script>
+    import Vue from "vue";
+    import Messages from "./Messages.vue";
+    import Player from "./Player.vue";
+    import TypingList from "./TypingList.vue";
+    import MessageForm from "./MessageForm.vue";
+
+    export default Vue.extend({
+        components: {Player, Messages, TypingList, MessageForm},
+        
+        props: {
+            hidePlayer: {
+                required: false,
+                default: false,
+                type: Boolean
+            }
+        },
+        methods: {
+            onSelectMessage: function(message) {
+
+                const editText = '/edit ' + message.id + ' ' + message.content;
+                const deleteText = '/delete ' + message.id;
+                const quoteText = '@' + message.id + ' ';
+                const rotation = [quoteText, editText, deleteText];
+                const currentContent = this.$refs.messageForm.getMessage();
+                const currentPosition = rotation.indexOf(currentContent);
+                const newPosition = (currentPosition + 1) % rotation.length;
+                this.$refs.messageForm.setMessage(rotation[newPosition]);
+            },
+        },
+        computed: {
+            playerState: function() {
+                return this.$store.state.playerState;
+            },
+            privateMessageChannel: function() {
+                return this.$store.state.channel;
+            },
+            privateMessages: function() {
+                if (! this.privateMessageChannel) {
+                    return [];
+                }
+                return this.$store.state.privateMessages[this.privateMessageChannel].messages;
+            },
+            messages: function() {
+                return this.$store.state.messages;
+            },
+        }
+    });
+</script>
+
+<style lang="scss" scoped>
+
+    .messages {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+
+        .player {
+            width: 100%;
+            height: 40%;
+            max-height: 350px;
+        }
+
+        .messages-feed {
+            flex-grow: 1;
+            margin-left: 10px;
+            margin-right: 10px;
+            height: 0;
+            overflow-y: scroll;
+            display: flex;
+            flex-direction: column;
+        }
+    }
+</style>

--- a/app/client/src/components/Message.vue
+++ b/app/client/src/components/Message.vue
@@ -1,10 +1,10 @@
 <template>
-    <div @contextmenu.prevent="$emit('select')" class="message" :style="{'border-left-color': message.user.data.plugins.color.main}">
-        <div class="avatar image-bubble" :style="{'box-shadow': '0 0 4px 4px ' + message.user.data.plugins.color.secondary}">
+    <div @contextmenu.prevent="$emit('select')" class="message" :style="{'border-left-color': message.user.data.plugins.color}">
+        <div class="avatar image-bubble" :style="{'box-shadow': message.user.data.plugins.halo ? '0 0 4px 4px ' + message.user.data.plugins.color : 'unset'}">
             <img :src="message.user.data.plugins.avatar">
         </div>
         <div class="content">
-            <div class="user" :style="{'color': message.user.data.plugins.color.main}">
+            <div class="user" :style="{'color': message.user.data.plugins.color}">
                 <i v-show="message.user.data.plugins.pinnedicon" class="material-icons md-14">{{message.user.data.plugins.pinnedicon}}</i>
                  {{message.user.username}}
                 <i v-show="message.meta.device === 'mobile'" class="material-icons user-device md-14">smartphone</i>

--- a/app/client/src/components/Messages.vue
+++ b/app/client/src/components/Messages.vue
@@ -1,19 +1,16 @@
 <template>
-    <div class="messages">
-        <player v-if="! hidePlayer" class="player" v-show="playerState && playerState.enabled"/>
-
-        <div class="messages-feed scrollbar"
-             ref="scroller"
-             @scroll="onScroll"
-             :style="smoothScroll ? 'scroll-behavior: smooth' : ''">
-            <message v-for="item in messages"
-                     @select="$emit('select-message', item)"
-                     @content-loaded="onContentLoaded"
-                     :key="item.id"
-                     :message="item"
-                     :seen-users="lastMessageSeenIds[item.id] || []"
-                     class="message"/>
-        </div>
+    <div class="messages-feed scrollbar"
+            ref="scroller"
+            @scroll="onScroll"
+            :style="smoothScroll ? 'scroll-behavior: smooth' : ''">
+            
+        <message v-for="item in messages"
+                    @select="$emit('select-message', item)"
+                    @content-loaded="onContentLoaded"
+                    :key="item.id"
+                    :message="item"
+                    :seen-users="lastMessageSeenIds[item.id] || []"
+                    class="message"/>
     </div>
 </template>
 
@@ -32,6 +29,10 @@
             };
         },
         props: {
+            messages: {
+                required: true,
+                type: Array,
+            },
             hidePlayer: {
                 required: false,
                 default: false,
@@ -110,12 +111,6 @@
             },
         },
         computed: {
-            messages: function() {
-                if (this.$store.state.channel) {
-                    return this.$store.state.privateMessages[this.$store.state.channel].messages;
-                }
-                return this.$store.state.messages;
-            },
             playerState: function() {
                 return this.$store.state.playerState;
             },
@@ -127,26 +122,13 @@
 </script>
 
 <style lang="scss" scoped>
-
-    .messages {
+    .messages-feed {
         flex-grow: 1;
+        margin-left: 10px;
+        margin-right: 10px;
+        height: 0;
+        overflow-y: scroll;
         display: flex;
         flex-direction: column;
-
-        .player {
-            width: 100%;
-            height: 40%;
-            max-height: 350px;
-        }
-
-        .messages-feed {
-            flex-grow: 1;
-            margin-left: 10px;
-            margin-right: 10px;
-            height: 0;
-            overflow-y: scroll;
-            display: flex;
-            flex-direction: column;
-        }
     }
 </style>

--- a/app/client/src/components/MessagesOverlay.vue
+++ b/app/client/src/components/MessagesOverlay.vue
@@ -1,28 +1,19 @@
 <template>
     <div class="messages-overlay">
         <quick-actions class="quick-actions"></quick-actions>
-        <messages :hide-player="true" ref="messages" @select-message="onSelectMessage" class="messages scrollbar" />
-        <typing-list class="typing-list" />
-        <message-form ref="messageForm" class="message-form"/>
+        <left-column :hide-player="true" />
     </div>
 </template>
 
 <script>
     import Vue from "vue";
-    import Messages from "./Messages.vue";
+    import LeftColumn from "./LeftColumn.vue";
     import TypingList from "./TypingList.vue";
     import MessageForm from "./MessageForm.vue";
     import QuickActions from "./QuickActions.vue";
 
     export default Vue.extend({
-        components: {Messages, TypingList, MessageForm, QuickActions},
-        methods: {
-            onSelectMessage: function() {
-
-            }
-        },
-        computed: {
-        }
+        components: {LeftColumn, TypingList, MessageForm, QuickActions},
     });
 </script>
 
@@ -31,10 +22,11 @@
 
     .quick-actions {
         margin-left: 6px;
+        padding-top: 4px;
     }
 
     .messages {
-        height: 200px;
+        height: 280px;
     }
 
     .typing-list {

--- a/app/client/src/components/PageContent.vue
+++ b/app/client/src/components/PageContent.vue
@@ -12,11 +12,10 @@
             <template v-if="! cinemaMode">
 
                 <section class="default-container">
+
                     <!-- left col -->
                     <section class="left hide-mobile-list">
-                        <messages ref="messages" @select-message="onSelectMessage" class="scrollbar" />
-                        <typing-list id="typing-list" />
-                        <message-form ref="messageForm" id="message-form"/>
+                        <left-column></left-column>
                     </section>
 
                     <!-- right col -->
@@ -43,9 +42,7 @@
 <script>
     import Vue from "vue";
     import AuthPage from "./AuthPage.vue";
-    import Messages from "./Messages.vue";
-    import TypingList from "./TypingList.vue";
-    import MessageForm from "./MessageForm.vue";
+    import LeftColumn from "./LeftColumn.vue";
     import Polls from "./Polls.vue";
     import UserPreview from "./UserPreview.vue";
     import PlayerPreview from "./PlayerPreview.vue";
@@ -55,7 +52,7 @@
     import MessagesOverlay from "./MessagesOverlay.vue";
 
     export default Vue.extend({
-        components: {AuthPage, Messages, TypingList, MessageForm, Polls, UserPreview, PlayerPreview, PlayerBackground, ConnectedList, QuickActions, MessagesOverlay},
+        components: {AuthPage, LeftColumn, Polls, UserPreview, PlayerPreview, PlayerBackground, ConnectedList, QuickActions, MessagesOverlay},
         watch: {
             cinemaMode: function() {
 
@@ -64,18 +61,6 @@
             },
         },
         methods: {
-
-            onSelectMessage: function(message) {
-
-                const editText = '/edit ' + message.id + ' ' + message.content;
-                const deleteText = '/delete ' + message.id;
-                const quoteText = '@' + message.id + ' ';
-                const rotation = [quoteText, editText, deleteText];
-                const currentContent = this.$refs.messageForm.getMessage();
-                const currentPosition = rotation.indexOf(currentContent);
-                const newPosition = (currentPosition + 1) % rotation.length;
-                this.$refs.messageForm.setMessage(rotation[newPosition]);
-            },
 
             gotoRoom() {
                 this.$store.commit('SET_PAGE', 'room');

--- a/app/client/src/components/PageContent.vue
+++ b/app/client/src/components/PageContent.vue
@@ -21,6 +21,7 @@
 
                     <!-- right col -->
                     <section class="right hide-mobile-tchat scrollbar">
+                        <user-preview></user-preview>
                         <player-preview></player-preview>
                         <polls></polls>
                         <connected-list></connected-list>
@@ -46,6 +47,7 @@
     import TypingList from "./TypingList.vue";
     import MessageForm from "./MessageForm.vue";
     import Polls from "./Polls.vue";
+    import UserPreview from "./UserPreview.vue";
     import PlayerPreview from "./PlayerPreview.vue";
     import PlayerBackground from "./PlayerBackground.vue";
     import ConnectedList from "./ConnectedList.vue";
@@ -53,7 +55,7 @@
     import MessagesOverlay from "./MessagesOverlay.vue";
 
     export default Vue.extend({
-        components: {AuthPage, Messages, TypingList, MessageForm, Polls, PlayerPreview, PlayerBackground, ConnectedList, QuickActions, MessagesOverlay},
+        components: {AuthPage, Messages, TypingList, MessageForm, Polls, UserPreview, PlayerPreview, PlayerBackground, ConnectedList, QuickActions, MessagesOverlay},
         watch: {
             cinemaMode: function() {
 

--- a/app/client/src/components/PageContent.vue
+++ b/app/client/src/components/PageContent.vue
@@ -121,7 +121,7 @@
                 width: 100%;
                 max-width: 380px;
                 background-color: #222223;
-                opacity: 0.4;
+                opacity: 0.75;
 
                 &:hover {
                     opacity: 1;

--- a/app/client/src/components/PlayerPreview.vue
+++ b/app/client/src/components/PlayerPreview.vue
@@ -1,39 +1,47 @@
 <template>
     <div class="youtube-preview" v-if="playerState">
-        <div class="current-video">
-            <div class="progress"><div class="progress-bar progress-bar-top" :class="'custom-color-' + progressBarColor" :style="{'width': (100 * cursorPercent) + '%'}"></div></div>
-            <div class="image-container">
-                <h3 class="preview-title">{{playerState.video.title}}</h3>
-                <div class="sliding-window up" :class="{['custom-color-' + progressBarColor]: true, closed: cursorPercent >= 1}"></div>
-                <div class="progress-vertical"><div class="progress-bar progress-bar-left" :class="'custom-color-' + progressBarColor" :style="{'height': (100 * cursorPercent) + '%'}"></div></div>
-                <img class="preview-thumb" :src="playerState.video.thumb">
-                <div class="progress-vertical"><div class="progress-bar progress-bar-right" :class="'custom-color-' + progressBarColor" :style="{'height': (100 * cursorPercent) + '%'}"></div></div>
-                <div class="sliding-window down" :class="{['custom-color-' + progressBarColor]: true, closed: cursorPercent >= 1}"></div>
-            </div>
-            <div class="progress"><div class="progress-bar progress-bar-bottom" :class="'custom-color-' + progressBarColor" :style="{'width': (100 * cursorPercent) + '%'}"></div></div>
+
+        <!-- preview container -->
+        <div class="preview-image-container">
+
+            <!-- progress bars -->
+            <div class="progress-bar progress-bar-top" :class="'custom-color-' + progressBarColor" :style="{'width': (100 * cursorPercent) + '%'}"></div>
+            <div class="progress-bar progress-bar-bottom" :class="'custom-color-' + progressBarColor" :style="{'width': (100 * cursorPercent) + '%'}"></div>
+            <div class="progress-bar progress-bar-left" :class="'custom-color-' + progressBarColor" :style="{'height': (100 * cursorPercent) + '%'}"></div>
+            <div class="progress-bar progress-bar-right" :class="'custom-color-' + progressBarColor" :style="{'height': (100 * cursorPercent) + '%'}"></div>
+
+            <!-- image preview -->
+            <img class="preview-thumb" :src="playerState.video.thumb">
+
+            <!-- title -->
+            <div class="preview-title">{{playerState.video.title}}</div>
+
+            <!-- sliding window that closes over the image -->
+            <div class="sliding-window top" :class="{['custom-color-' + progressBarColor]: true, 'closed': cursorPercent >= 1}"></div>
+            <div class="sliding-window bottom" :class="{['custom-color-' + progressBarColor]: true, 'closed': cursorPercent >= 1}"></div>
         </div>
-        <div class="queue" v-show="nextVideos.length > 0">
-            <div class="vertical-bar" :class="'custom-color-' + progressBarColor"></div>
-            <transition-group name="list" tag="div">
-                <div v-for="video, videoIndex in nextVideos"
-                    class="video-in-queue"
-                    :key="video.video.id">
-                    <div class="image avatar">
-                        <div class="image-bubble" :style="'box-shadow: #' + progressBarColor +' 0 0 4px 0;'">
-                            <img data-v-193da69e="" :src="video.video.thumb">
-                        </div>
-                    </div>
-                    <!-- the svg has -5px left and top to avoid the circles being truncated -->
-                    <svg height="50" width="50">
-                        <circle cx="25" cy="25" r="20" fill="none" stroke="black"></circle>
-                        <circle cx="25" cy="25" r="20" :class="'custom-color-' + progressBarColor" :stroke-dashoffset="- (queueWaitDurations[videoIndex]) * 2 * Math.PI * 25"></circle>
-                    </svg>
-                    <div class="info">
-                        <div class="title">{{video.video.title}}</div>
-                        <div class="user">- {{video.user.username}}</div>
+
+        <!-- youtube queue -->
+        <div class="queue scrollbar" v-show="nextVideos.length > 0">
+            
+            <div v-for="video, videoIndex in nextVideos"
+                class="video-in-queue"
+                :key="video.video.id"
+                :title="video.video.title + ': added by ' + video.user.username">
+
+                <!-- video preview image -->
+                <div class="image avatar">
+                    <div class="image-bubble" :style="'box-shadow: #' + progressBarColor +' 0 0 4px 0;'">
+                        <img data-v-193da69e="" :src="video.video.thumb">
                     </div>
                 </div>
-            </transition-group>
+
+                <!-- the svg has -5px left and top to avoid the circles being truncated -->
+                <svg height="50" width="50">
+                    <circle cx="25" cy="25" r="20" fill="none" stroke="black"></circle>
+                    <circle cx="25" cy="25" r="20" :class="'custom-color-' + progressBarColor" :stroke-dashoffset="- (queueWaitDurations[videoIndex]) * 2 * Math.PI * 25"></circle>
+                </svg>
+            </div>
         </div>
     </div>
 </template>
@@ -109,7 +117,7 @@
             },
             nextVideos: function() {
                 if (this.playerState) {
-                    return this.playerState.queue.slice(0, 4);
+                    return this.playerState.queue.slice(0, 30);
                 } else {
                     return [];
                 }
@@ -119,33 +127,70 @@
 </script>
 
 <style lang="scss" scoped>
+
     .youtube-preview {
-        padding-top: 20px;
+
+        width: 100%;
+        height: 160px;
+        display: flex;
+        margin-top: 10px;
         padding-right: 20px;
         padding-left: 6px;
         color: white;
 
-        .preview-title {
-            position: absolute;
-            left: 10px;
-            top: 3px;
-            white-space: nowrap;
-            overflow: hidden;
-            -ms-text-overflow: ellipsis;
-            text-overflow: ellipsis;
-            margin-bottom: 2px;
-            width: 100%;
-        }
-
-        .image-container {
-            display: flex;
-            height: 176px;
-            width: 100%;
+        >.preview-image-container {
             position: relative;
-            overflow: hidden;
-            z-index: 1;
+            flex-basis: 284.444444444px;
+            background-color: black;
+            
+            > .progress-bar {
+                position: absolute;
+                transition: all 1s ease-in-out;
 
-            >.sliding-window {
+                &.progress-bar-top {
+                    height: 4px;
+                    top: 0;
+                    right: 0;
+                }
+                &.progress-bar-bottom {
+                    height: 4px;
+                    bottom: 0;
+                    left: 0;
+                }
+                &.progress-bar-left {
+                    width: 2px;
+                    left: 0;
+                    bottom: 0;
+                }
+                &.progress-bar-right {
+                    width: 2px;
+                    right: 0;
+                    top: 0;
+                }
+            }
+
+            > .preview-thumb {
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                padding: 2px;
+            }
+
+            > .preview-title {
+                position: absolute;
+                left: 8px;
+                top: 5px;
+                white-space: nowrap;
+                overflow: hidden;
+                -ms-text-overflow: ellipsis;
+                text-overflow: ellipsis;
+                margin-bottom: 2px;
+                width: calc(100% - 16px);
+                font-size: 120%;
+                font-weight: 600;
+            }
+
+            > .sliding-window {
                 width: 100%;
                 position: absolute;
                 left: 0;
@@ -156,34 +201,25 @@
                 -o-transition: all 1s ease-in-out;
                 transition: all 1s ease-in-out;
 
-                &.up {
+                &.top {
                     top: 0;
                 }
-                &.down {
+                &.bottom {
                     bottom: 0;
                 }
                 &.closed {
                     height: 50%;
                 }
             }
+        }
 
-            >.progress-vertical {
-                flex-basis: 2px;
-                position: relative;
-
-                >.progress-bar {
-                    width: 100%;
-                    position: absolute;
-                    transition: all 1s ease-in-out;
-
-                    &.progress-bar-left {
-                        bottom: 0;
-                    }
-                    &.progress-bar-right {
-                        top: 0;
-                    }
-                }
-            }
+        .image-container {
+            display: flex;
+            height: 176px;
+            width: 100%;
+            position: relative;
+            overflow: hidden;
+            z-index: 1;
 
             >.preview-thumb {
                 flex-grow: 1;
@@ -235,26 +271,21 @@
         }
 
         .queue {
+            flex-grow: 1;
+            flex-basis: 0px;
+            overflow-y: auto;
             display: flex;
-            flex-direction: column;
+            flex-wrap: wrap;
+            justify-content: center;
             position: relative;
             background: #2b2b2f;
-            padding-right: 30px;
-            padding-left: 10px;
-            padding-bottom: 10px;
+            padding: 4px;
 
-            .vertical-bar {
-                position: absolute;
-                transition: all 1s ease-in-out;
-                width: 2px;
-                height: calc(100% - 30px);
-                left: 30px;
-            }
             .video-in-queue {
                 display: flex;
-                width: 100%;
+                width: 40px;
                 height: 40px;
-                margin: 10px 0 5px 0;
+                margin: 5px;
                 position: relative;
 
                 .image {
@@ -280,38 +311,8 @@
                         transform: rotate(-85deg);
                         animation: rotate 60s linear infinite;
                     }
-
-                    @keyframes rotate {
-                        to {
-                        }
-                    }
-                }
-                .info {
-                    width: 0;
-                    flex-grow: 1;
-                    display: flex;
-                    flex-direction: column;
-                    padding: 5px;
-                    margin-left: 6px;
-
-                    >.title {
-                        white-space: nowrap;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                    }
                 }
             }
-        }
-
-        .list-enter-active, .list-leave-active {
-            transition: all 1s;
-        }
-        .list-leave-to {
-            margin-top: -60px !important;
-            margin-bottom: 40px !important;
-        }
-        .list-enter {
-            opacity: 0;
         }
     }
 </style>

--- a/app/client/src/components/QuickActions.vue
+++ b/app/client/src/components/QuickActions.vue
@@ -208,9 +208,9 @@
                         this.$modal.show(YoutubeVideoSearcher);
                         return;
                     case 'shop-color':
-                        return this.$client.sendMessage('/shoplist color.main');
+                        return this.$client.sendMessage('/shoplist color');
                     case 'shop-halo':
-                        return this.$client.sendMessage('/shoplist color.secondary');
+                        return this.$client.sendMessage('/shoplist halo');
                     case 'shop-pinnedicon':
                         return this.$client.sendMessage('/shoplist pinnedicon');
                     case 'guess':

--- a/app/client/src/components/UserPreview.vue
+++ b/app/client/src/components/UserPreview.vue
@@ -36,7 +36,7 @@
                 if (! this.nextRank) {
                     return 0;                
                 }
-                return Math.floor(100 * (this.user.xp - this.currentRank.limit) / (this.nextRank.limit - this.currentRank.limit));
+                return Math.max(1, Math.floor(100 * (this.user.xp - this.currentRank.limit) / (this.nextRank.limit - this.currentRank.limit)));
             },
             currentRank: function() {
                 return this.config.ranks.filter(rank => this.user.xp >= rank.limit)[0];

--- a/app/client/src/components/UserPreview.vue
+++ b/app/client/src/components/UserPreview.vue
@@ -1,0 +1,89 @@
+<template>
+
+    <div class="mt-2 pr-2 pl-1">
+
+        <!-- rank progress bar -->
+        <div class="progress-bar">
+
+            <!-- Progress bar -->
+            <div class="progress-bar-progress" :style="{width: xpProgressPct + '%'}"></div>
+
+            <!-- Rank icons -->
+            <div class="rank current-rank" :title="'Current rank unlocked at ' + currentRank.limit + ' xp'"><img :src="'/assets/images/' + currentRank.rank"></div>
+            <div class="rank next-rank" :title="'Next rank at ' + nextRank.limit + ' xp'" v-if="nextRank"><img :src="'/assets/images/' + nextRank.rank"></div>
+        </div>
+
+    </div>
+</template>
+
+<script>
+    import Vue from "vue";
+
+    export default Vue.extend({
+        data: function() {
+            return {
+
+            }
+        },
+        computed: {
+            user: function() {
+                return this.$store.state.user;
+            },
+            config: function() {
+                return this.$store.state.config;
+            },
+            xpProgressPct: function() {
+                if (! this.nextRank) {
+                    return 0;                
+                }
+                return Math.floor(100 * (this.user.xp - this.currentRank.limit) / (this.nextRank.limit - this.currentRank.limit));
+            },
+            currentRank: function() {
+                return this.config.ranks.filter(rank => this.user.xp >= rank.limit)[0];
+            },
+            nextRank: function() {
+                const remainingRanks = this.config.ranks.filter(rank => this.user.xp < rank.limit);
+                if (remainingRanks.length === 0) {
+                    return null;
+                }
+                return remainingRanks[remainingRanks.length - 1];
+            }
+        }
+    });
+</script>
+
+<style lang="scss" scoped>
+
+.progress-bar {
+    width: 100%;
+    border: 4px solid #2c2d31;
+    background-color: #2c2d31;
+    border-radius: 22px;
+    height: 18px;
+    position: relative;
+
+    >.rank {
+        position: absolute;
+        top: -10px;
+
+        &.current-rank {
+            left: 0;
+        }
+        
+        &.next-rank {
+            right: 0;
+        }
+    }
+
+    .progress-bar-progress {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        background-color: #8b3742;
+        border-top-left-radius: 22px;
+        border-bottom-left-radius: 22px;
+    }
+}
+
+</style>

--- a/app/client/src/components/UserPreview.vue
+++ b/app/client/src/components/UserPreview.vue
@@ -1,18 +1,31 @@
 <template>
 
-    <div class="mt-2 pr-2 pl-1">
+    <div class="user-preview pr-2 pl-1 mt-1">
 
-        <!-- rank progress bar -->
-        <div class="progress-bar">
-
-            <!-- Progress bar -->
-            <div class="progress-bar-progress" :style="{width: xpProgressPct + '%'}"></div>
-
-            <!-- Rank icons -->
-            <div class="rank current-rank" :title="'Current rank unlocked at ' + currentRank.limit + ' xp'"><img :src="'/assets/images/' + currentRank.rank"></div>
-            <div class="rank next-rank" :title="'Next rank at ' + nextRank.limit + ' xp'" v-if="nextRank"><img :src="'/assets/images/' + nextRank.rank"></div>
+        <div class="user-preview-avatar">
+            <div class="image-bubble" >
+                <img :src="user.data.plugins.avatar">
+            </div>
         </div>
 
+        <div class="user-preview-info">
+            
+            <div class="session"
+                 :style="{'color': user.data.plugins.color}">
+                {{user.username}}
+            </div>
+
+            <!-- rank progress bar -->
+            <div class="progress-bar">
+
+                <!-- Progress bar -->
+                <div class="progress-bar-progress" :style="{width: xpProgressPct + '%'}"></div>
+
+                <!-- Rank icons -->
+                <div class="rank current-rank" :title="'Current rank unlocked at ' + currentRank.limit + ' xp'"><img :src="'/assets/images/' + currentRank.rank"></div>
+                <div class="rank next-rank" :title="'Next rank at ' + nextRank.limit + ' xp'" v-if="nextRank"><img :src="'/assets/images/' + nextRank.rank"></div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -54,36 +67,73 @@
 
 <style lang="scss" scoped>
 
-.progress-bar {
-    width: 100%;
-    border: 4px solid #2c2d31;
-    background-color: #2c2d31;
-    border-radius: 22px;
-    height: 18px;
-    position: relative;
+.user-preview {
 
-    >.rank {
-        position: absolute;
-        top: -10px;
+    display: flex;
 
-        &.current-rank {
-            left: 0;
-        }
-        
-        &.next-rank {
-            right: 0;
+    > .user-preview-avatar {
+        width: 65px;
+        height: 65px;
+        padding: 10px;
+        position: relative;
+
+        >.image-bubble{
+            width: 100%;
+            height: 100%;
         }
     }
 
-    .progress-bar-progress {
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        background-color: #8b3742;
-        border-top-left-radius: 22px;
-        border-bottom-left-radius: 22px;
+    > .user-preview-info {
+
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        padding-top: 8px;
+        padding-left: 12px;
+        padding-right: 22px;
+
+        >.session {
+            display: inline;
+            color: #a3a5b4;
+            font-weight: 800;
+            font-size: 110%;
+            flex-basis: 20px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin-bottom: 6px;
+        }
+
+        > .progress-bar {
+            width: 100%;
+            border: 4px solid #2c2d31;
+            background-color: #2c2d31;
+            border-radius: 22px;
+            height: 18px;
+            position: relative;
+
+            >.rank {
+                position: absolute;
+                top: -10px;
+
+                &.current-rank {
+                    left: 0;
+                }
+                
+                &.next-rank {
+                    right: 0;
+                }
+            }
+
+            .progress-bar-progress {
+                position: absolute;
+                top: 0;
+                left: 0;
+                height: 100%;
+                background-color: #8b3742;
+                border-top-left-radius: 22px;
+                border-bottom-left-radius: 22px;
+            }
+        }
     }
 }
-
 </style>

--- a/app/client/src/skychat/SkyChatClient.js
+++ b/app/client/src/skychat/SkyChatClient.js
@@ -28,6 +28,7 @@ export class SkyChatClient extends EventEmitter {
      * Bind own event listeners
      */
     bind() {
+        this.on('config', this.onConfig.bind(this));
         this.on('join-room', this.onJoinRoom.bind(this));
         this.on('message', this.onMessage.bind(this));
         this.on('messages', this.onMessages.bind(this));
@@ -85,6 +86,13 @@ export class SkyChatClient extends EventEmitter {
      */
     onPing() {
         this.sendEvent('pong', null);
+    }
+
+    /**
+     * When receiving config object from server
+     */
+    onConfig(config) {
+        this.store.commit('SET_CONFIG', config);
     }
 
     /**

--- a/app/client/src/store/store.js
+++ b/app/client/src/store/store.js
@@ -18,13 +18,13 @@ const store = {
         connectionState: WebSocket.CLOSED,
         user: {
             id: 0,
-            username: '*Hamster0',
+            username: '*Guest',
             money: 0,
             xp: 0,
             right: -1,
             data: {
                 plugins: {
-                    avatar: "https://risibank.fr/cache/stickers/d666/66604-thumb.png",
+                    avatar: "",
                     cursor: true,
                     moto: "",
                 }
@@ -97,7 +97,16 @@ const store = {
         },
         SET_CONNECTED_LIST(state, entries) {
             state.connectedList = entries;
+
+            // Update hash list of last message seen ids
             this.commit('GENERATE_LAST_MESSAGE_SEEN_IDS');
+
+            // Update self entry
+            const selfEntry = entries.find(entry => entry.user.username === state.user.username);
+            if (! selfEntry) {
+                return;
+            }
+            this.commit('SET_USER', selfEntry.user);
         },
         MESSAGE_SEEN(state, data) {
             const entry = state.connectedList.find(e => e.user.id === data.user);

--- a/app/client/src/store/store.js
+++ b/app/client/src/store/store.js
@@ -12,6 +12,7 @@ const store = {
         documentTitleBlinking: false,
         page: 'welcome',
         mobileCurrentPage: 'tchat',
+        config: null,
         cinemaMode: false,
         channel: null,
         connectionState: WebSocket.CLOSED,
@@ -81,6 +82,9 @@ const store = {
         },
         GOTO_MAIN_CHANNEL(state) {
             state.channel = null;
+        },
+        SET_CONFIG(state, config) {
+            state.config = config;
         },
         SET_CONNECTION_STATE(state, connectionState) {
             state.connectionState = connectionState;

--- a/app/server/skychat/Config.ts
+++ b/app/server/skychat/Config.ts
@@ -3,9 +3,14 @@ import * as Mail from "nodemailer/lib/mailer";
 
 
 export type Preferences = {
+    ranks: {limit: number, rank: string}[],
     plugins: string[],
     fakeMessages: string[],
     guestNames: string[],
+}
+
+export type PublicConfig = {
+    ranks: {limit: number, rank: string}[],
 }
 
 export class Config {
@@ -45,6 +50,12 @@ export class Config {
 
     public static getPlugins(): string[] {
         return Config.PREFERENCES.plugins;
+    }
+
+    public static toClient(): PublicConfig {
+        return {
+            ranks: Config.PREFERENCES.ranks,
+        }
     }
 
     public static initialize() {

--- a/app/server/skychat/Server.ts
+++ b/app/server/skychat/Server.ts
@@ -143,15 +143,15 @@ export class Server {
         // Create a new connection object & attach it to the session
         const connection = new Connection(session, webSocket, request);
 
+        if (typeof this.onConnectionCreated === 'function') {
+            await this.onConnectionCreated(connection);
+        }
+
         // For every registered event
         Object.keys(this.events).forEach(eventName => {
             // Register it on the connection object
             connection.on(eventName, (payload: any) => this.onConnectionEvent(eventName, payload, connection));
         });
-
-        if (typeof this.onConnectionCreated === 'function') {
-            await this.onConnectionCreated(connection);
-        }
     }
 
     /**

--- a/app/server/skychat/SkyChat.ts
+++ b/app/server/skychat/SkyChat.ts
@@ -143,7 +143,7 @@ export class SkyChat {
      * @param connection
      */
     private async onConnectionCreated(connection: Connection): Promise<void> {
-
+        connection.send('config', Config.toClient());
     }
 
     private async onRegister(payload: any, connection: Connection): Promise<void> {

--- a/app/server/skychat/User.ts
+++ b/app/server/skychat/User.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash"
-import {UserController} from "./UserController"; // Import the entire lodash library
+import { UserController } from "./UserController";
+import { Config } from "./Config";
 
 
 export type UserData = {
@@ -35,19 +36,7 @@ export class User {
         plugins: {}
     };
 
-
-    public static readonly RANK_LIMITS: {limit: number, rank: string}[] = [
-        {limit: 100000, rank: 'rank_9.gif'},
-        {limit: 65000, rank: 'rank_8.png'},
-        {limit: 50000, rank: 'rank_7.png'},
-        {limit: 35000, rank: 'rank_6.png'},
-        {limit: 20000, rank: 'rank_5.png'},
-        {limit: 10000, rank: 'rank_4.png'},
-        {limit: 4000, rank: 'rank_3.png'},
-        {limit: 800, rank: 'rank_2.png'},
-        {limit: 200, rank: 'rank_1.png'},
-        {limit: 0, rank: 'rank_0.png'},
-    ];
+    public static readonly RANK_LIMITS: {limit: number, rank: string}[] = Config.PREFERENCES.ranks;
 
     /**
      * Get the rank image of this user from an xp amount

--- a/app/server/skychat/commands/impl/customization/HaloPlugin.ts
+++ b/app/server/skychat/commands/impl/customization/HaloPlugin.ts
@@ -2,16 +2,14 @@ import {Connection} from "../../../Connection";
 import {Plugin} from "../../Plugin";
 
 
-export class ColorPlugin extends Plugin {
+export class HaloPlugin extends Plugin {
 
-    static readonly DEFAULT_MAIN: string = '#aaaaaa';
+    readonly defaultDataStorageValue = false;
 
-    readonly defaultDataStorageValue = ColorPlugin.DEFAULT_MAIN;
-
-    readonly name = 'color';
+    readonly name = 'halo';
 
     readonly callable = false;
-
+    
     async run(alias: string, param: string, connection: Connection): Promise<void> {
         throw new Error('This command can not be run');
     }

--- a/app/server/skychat/commands/impl/customization/ShopPlugin.ts
+++ b/app/server/skychat/commands/impl/customization/ShopPlugin.ts
@@ -26,9 +26,9 @@ export type ShopItem = {
 export class ShopPlugin extends Plugin {
 
     public static readonly COLORS_TIER_0_COST: number = 0;
-    public static readonly COLORS_TIER_1_COST: number = 500;
-    public static readonly COLORS_TIER_2_COST: number = 1500;
-    public static readonly COLORS_TIER_3_COST: number = 3000;
+    public static readonly COLORS_TIER_1_COST: number = 2 * 100;
+    public static readonly COLORS_TIER_2_COST: number = 25 * 100;
+    public static readonly COLORS_TIER_3_COST: number = 50 * 100;
 
     public static readonly ITEMS: {[type: string]: ShopItems} = {
         'color': {
@@ -75,7 +75,7 @@ export class ShopPlugin extends Plugin {
         'halo': {
             items: [
                 {id: 0, name: 'no halo', value: false, price: 0},
-                {id: 1, name: 'halo', value: true, price: ShopPlugin.COLORS_TIER_3_COST},
+                {id: 1, name: 'halo', value: true, price: 50 * 100},
             ],
             preview: (value, user) => `
                 <div style="color:${user.data.plugins.color};border-left: 4px solid ${user.data.plugins.color};padding-left: 6px;">

--- a/app/server/skychat/commands/impl/customization/ShopPlugin.ts
+++ b/app/server/skychat/commands/impl/customization/ShopPlugin.ts
@@ -66,7 +66,7 @@ export class ShopPlugin extends Plugin {
             ],
             preview: (value, user) => `
                 <div style="color:${value};border-left: 4px solid ${value};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:2px 2px 3px 2px ${user.data.plugins.color.secondary}">&nbsp;</div>
+                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${user.data.plugins.halo ? '2px 2px 3px 2px ' + value : 'unset'}">&nbsp;</div>
                     <b>${user.username}</b>
                 </div>
             `,
@@ -152,8 +152,10 @@ export class ShopPlugin extends Plugin {
                 price: data[1] === '' ? 0 : 5000
             })),
             preview: (value, user) => `
-                <div style="color:${user.data.plugins.color.main};border-left: 4px solid ${user.data.plugins.color.main};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:2px 2px 3px 2px ${user.data.plugins.color.secondary}">&nbsp;</div>
+                <div style="color:${user.data.plugins.color};border-left: 4px solid ${user.data.plugins.color};padding-left: 6px;">
+                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${user.data.plugins.halo ? '2px 2px 3px 2px ' + user.data.plugins.color : 'unset'}">
+                        &nbsp;
+                    </div>
                     <i class="material-icons md-14">${value}</i> <b>${user.username}</b>
                 </div>
             `,

--- a/app/server/skychat/commands/impl/customization/ShopPlugin.ts
+++ b/app/server/skychat/commands/impl/customization/ShopPlugin.ts
@@ -31,7 +31,7 @@ export class ShopPlugin extends Plugin {
     public static readonly COLORS_TIER_3_COST: number = 3000;
 
     public static readonly ITEMS: {[type: string]: ShopItems} = {
-        'color.main': {
+        'color': {
             items: [
                 {id: 0, name: 'default', value: ColorPlugin.DEFAULT_MAIN, price: ShopPlugin.COLORS_TIER_0_COST},
 
@@ -70,35 +70,22 @@ export class ShopPlugin extends Plugin {
                     <b>${user.username}</b>
                 </div>
             `,
-            sellRatio: 0.5,
+            sellRatio: 0.4,
         },
-        'color.secondary': {
+        'halo': {
             items: [
-                {id: 0, name: 'default', value: ColorPlugin.DEFAULT_SECONDARY, price: ShopPlugin.COLORS_TIER_0_COST},
-
-                {id: 1, name: 'white', value: '#ffffff', price: ShopPlugin.COLORS_TIER_1_COST},
-                {id: 2, name: 'black', value: '#000000', price: ShopPlugin.COLORS_TIER_1_COST},
-
-                {id: 3, name: 'purple', value: '#ae1e68', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 4, name: 'rebeccapurple', value: '#a348ff', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 5, name: 'royalblue', value: '#4169e1', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 6, name: 'oldblue', value: '#4c80bb', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 7, name: 'turquoise', value: '#40e0d0', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 8, name: 'limegreen', value: '#32cd32', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 9, name: 'yellow', value: '#e4e400', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 10, name: 'orange', value: '#e67e00', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 11, name: 'orangered', value: '#ff4500', price: ShopPlugin.COLORS_TIER_3_COST},
-                {id: 12, name: 'bestred', value: '#ff2424', price: ShopPlugin.COLORS_TIER_3_COST},
+                {id: 0, name: 'no halo', value: false, price: 0},
+                {id: 1, name: 'halo', value: true, price: ShopPlugin.COLORS_TIER_3_COST},
             ],
             preview: (value, user) => `
-                <div style="color:${user.data.plugins.color.main};border-left: 4px solid ${user.data.plugins.color.main};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:2px 2px 3px 2px ${user.data.plugins.color.secondary}">
+                <div style="color:${user.data.plugins.color};border-left: 4px solid ${user.data.plugins.color};padding-left: 6px;">
+                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${value ? '2px 2px 3px 2px ' + user.data.plugins.color : 'unset'}">
                         &nbsp;
                     </div>
                     <b>${user.username}</b>
                 </div>
             `,
-            sellRatio: 0.5,
+            sellRatio: 0.4,
         },
         'pinnedicon': {
             items: [
@@ -170,11 +157,11 @@ export class ShopPlugin extends Plugin {
                     <i class="material-icons md-14">${value}</i> <b>${user.username}</b>
                 </div>
             `,
-            sellRatio: 0.5,
+            sellRatio: 0.4,
         }
     };
 
-    public static readonly TYPE_REGEXP: RegExp = /^(color\.main|color\.secondary|pinnedicon)$/;
+    public static readonly TYPE_REGEXP: RegExp = /^(color|halo|pinnedicon)$/;
 
     readonly defaultDataStorageValue: {[type: string]: number[]} = {colors: []};
 
@@ -415,15 +402,10 @@ export class ShopPlugin extends Plugin {
         }
 
         switch (type) {
-            case 'color.main':
-            case 'color.secondary':
-                const data = await UserController.getPluginData(user, 'color');
-                data[type.split('.')[1]] = item.value;
-                await UserController.savePluginData(user, 'color', data);
-                break;
-            
+            case 'color':
+            case 'halo':
             case 'pinnedicon':
-                await UserController.savePluginData(user, 'pinnedicon', item.value);
+                await UserController.savePluginData(user, type, item.value);
                 break;
         }
     }
@@ -443,13 +425,10 @@ export class ShopPlugin extends Plugin {
         }
 
         switch (type) {
-            case 'color.main':
-            case 'color.secondary':
-                const subCategory = type.split('.')[1];
-                return (await UserController.getPluginData(user, 'color'))[subCategory] === item.value;
-            
+            case 'color':
+            case 'halo':
             case 'pinnedicon':
-                return (await UserController.getPluginData(user, 'pinnedicon')) === item.value;
+                return (await UserController.getPluginData(user, type)) === item.value;
         }
     }
 

--- a/app/server/skychat/commands/impl/index.ts
+++ b/app/server/skychat/commands/impl/index.ts
@@ -29,6 +29,7 @@ export {PollPlugin} from "./poll/PollPlugin";
 export {XPFarmerPlugin} from "./core/XPFarmerPlugin";
 export {BanPlugin} from "./moderation/BanPlugin";
 export {UsurpPlugin} from "./moderation/UsurpPlugin";
+export {LogFuzzerPlugin} from "./optional/LogFuzzerPlugin";
 export {AccountPlugin} from "./core/AccountPlugin";
 export {MailPlugin} from "./core/MailPlugin";
 export {TrackerPlugin} from "./moderation/TrackerPlugin";

--- a/app/server/skychat/commands/impl/index.ts
+++ b/app/server/skychat/commands/impl/index.ts
@@ -12,6 +12,7 @@ export {ConnectedListPlugin} from "./core/ConnectedListPlugin";
 export {PrivateMessagePlugin} from "./core/PrivateMessagePlugin";
 export {SetRightCommand} from "./moderation/SetRightCommand";
 export {ColorPlugin} from "./customization/ColorPlugin";
+export {HaloPlugin} from "./customization/HaloPlugin";
 export {ShopPlugin} from "./customization/ShopPlugin";
 export {MoneyFarmerPlugin} from "./core/MoneyFarmerPlugin";
 export {OfferMoneyPlugin} from "./moderation/OfferMoneyPlugin";

--- a/app/server/skychat/commands/impl/optional/LogFuzzerPlugin.ts
+++ b/app/server/skychat/commands/impl/optional/LogFuzzerPlugin.ts
@@ -1,0 +1,65 @@
+import { Connection } from "../../../Connection";
+import { Room } from "../../../Room";
+import { Message } from "../../../Message";
+import { DatabaseHelper } from "../../../DatabaseHelper";
+import { Plugin } from "../../Plugin";
+import SQL from "sql-template-strings";
+
+
+export class LogFuzzerPlugin extends Plugin {
+
+    readonly name = 'logfuzzer';
+
+    readonly minRight = -1;
+
+    readonly rules = {
+        logfuzzer: { }
+    };
+
+    /**
+     * Last fuzzed message id in history
+     */
+    protected storage: number = 0;
+
+    private tickTimeout?: NodeJS.Timeout;
+
+    constructor(room: Room) {
+        super(room);
+
+        this.loadStorage();
+
+        if (room) {
+            this.tickTimeout = setInterval(this.tick.bind(this), 5 * 1000);
+        }
+    }
+
+    async run(alias: string, param: string, connection: Connection): Promise<void> {
+        throw new Error('This plugin is not callable');        
+    }
+
+    private fuzzContent(content: string) {
+        return content.replace(/(^| |,|\/|.)([a-z0-9-]+)/gi, (m0, m1, m2) => {
+            let newStr = '';
+            for (const char of m2) {
+                if (char === char.toUpperCase()) {
+                    newStr += 'A';
+                } else {
+                    newStr += 'a';
+                }
+            }
+            return m1 + newStr;
+        });
+    }
+
+    async tick(): Promise<void> {
+        const sqlQuery = SQL`select id, content from messages where id > ${this.storage}`;
+        const messages: {content: string, id: number}[] = await DatabaseHelper.db.all(sqlQuery);
+        for (const {id, content} of messages) {
+            const sqlQuery = SQL`update messages set content=${this.fuzzContent(content)} where id=${id}`;
+            await DatabaseHelper.db.run(sqlQuery);
+        }
+        const maxId = Math.max(...messages.map(message => message.id));
+        this.storage = maxId;
+        this.syncStorage();
+    }
+}

--- a/app/server/skychat/commands/impl/optional/LogFuzzerPlugin.ts
+++ b/app/server/skychat/commands/impl/optional/LogFuzzerPlugin.ts
@@ -65,7 +65,6 @@ export class LogFuzzerPlugin extends Plugin {
         }
         if (messages.length > 0) {
             const maxId = Math.max(...messages.map(message => message.id));
-            console.log(messages.length, maxId, messages[0]);
             this.storage.lastId = maxId;
             this.syncStorage();
         }

--- a/app/server/skychat/commands/impl/youtube/YoutubePlugin.ts
+++ b/app/server/skychat/commands/impl/youtube/YoutubePlugin.ts
@@ -287,6 +287,7 @@ export class YoutubePlugin extends Plugin {
             return;
         }
         this.storage.currentVideo = null;
+        this.sync(this.room);
     }
 
     /**

--- a/config.json.template
+++ b/config.json.template
@@ -1,14 +1,14 @@
 {
     "ranks": [
         {"limit": 100000, "rank": "rank_9.gif"},
-        {"limit": 65000, "rank": "rank_8.png"},
+        {"limit": 70000, "rank": "rank_8.png"},
         {"limit": 50000, "rank": "rank_7.png"},
-        {"limit": 35000, "rank": "rank_6.png"},
-        {"limit": 20000, "rank": "rank_5.png"},
-        {"limit": 10000, "rank": "rank_4.png"},
-        {"limit": 4000, "rank": "rank_3.png"},
-        {"limit": 800, "rank": "rank_2.png"},
-        {"limit": 200, "rank": "rank_1.png"},
+        {"limit": 30000, "rank": "rank_6.png"},
+        {"limit": 15000, "rank": "rank_5.png"},
+        {"limit": 8000, "rank": "rank_4.png"},
+        {"limit": 1300, "rank": "rank_3.png"},
+        {"limit": 300, "rank": "rank_2.png"},
+        {"limit": 30, "rank": "rank_1.png"},
         {"limit": 0, "rank": "rank_0.png"}
     ],
     "plugins": [

--- a/config.json.template
+++ b/config.json.template
@@ -1,4 +1,16 @@
 {
+    "ranks": [
+        {"limit": 100000, "rank": "rank_9.gif"},
+        {"limit": 65000, "rank": "rank_8.png"},
+        {"limit": 50000, "rank": "rank_7.png"},
+        {"limit": 35000, "rank": "rank_6.png"},
+        {"limit": 20000, "rank": "rank_5.png"},
+        {"limit": 10000, "rank": "rank_4.png"},
+        {"limit": 4000, "rank": "rank_3.png"},
+        {"limit": 800, "rank": "rank_2.png"},
+        {"limit": 200, "rank": "rank_1.png"},
+        {"limit": 0, "rank": "rank_0.png"}
+    ],
     "plugins": [
         "AccountPlugin",
         "AvatarPlugin",


### PR DESCRIPTION
- Halo colors can now only match user color
- Introduced a log fuzzer plugin that replaces all words in logs by `a` and `A` (if you do not want logging on your instance but you still would like to make some analytics, this can be useful)
- Improved UI performances: switching from/to private messages no longer destroy/re-creates the main message feed
- Fix the yt player not being synchronized after a /yt skip when it is the last playing video in the list
- Adjust shop pricings
- Improve overall styling of the right column to optimize vertical space