### PR TITLE
Fix responsiveness when using Safari/525.20.1+

### DIFF
--- a/app/client/src/components/Message.vue
+++ b/app/client/src/components/Message.vue
@@ -92,7 +92,7 @@
 
     .message {
         display: flex;
-	flex: 0 0 auto;
+        flex: 0 0 auto;
         color: white;
         background: #2b2b2f;
         margin-top: 4px;

--- a/app/client/src/components/Message.vue
+++ b/app/client/src/components/Message.vue
@@ -92,6 +92,7 @@
 
     .message {
         display: flex;
+	flex: 0 0 auto;
         color: white;
         background: #2b2b2f;
         margin-top: 4px;


### PR DESCRIPTION
Responsiveness is unoptimized when the user render the chat through Safari. 
The chatbox used to be compressed to the point where messages were unreadable: 

![125311079_670225087024843_1601730850933509202_n](https://user-images.githubusercontent.com/74500085/99189662-8feec400-2762-11eb-8cb2-4bf21f2ca0a4.jpg)

Specifying the flex attribute boxes each message in their correct display:

![125344857_407057757328104_6956741083727437088_n](https://user-images.githubusercontent.com/74500085/99189724-cdebe800-2762-11eb-9acd-df78957f8218.jpg)

This fix is directed toward improving the user experience. 

## How to reproduce:
Step 1: Don't be poor
Step 2: Use your iPhone to visit the chat
Step 3: Squint as hard as you can in order to read even the most simple message