### PR TITLE
Prevent loading stickers when the json list is empty in MessageHistory

### DIFF
--- a/app/server/skychat/commands/impl/core/MessageHistoryPlugin.ts
+++ b/app/server/skychat/commands/impl/core/MessageHistoryPlugin.ts
@@ -37,16 +37,15 @@ export class MessageHistoryPlugin extends Plugin {
          */
         // Send message history to the connection that just joined this room
         const fakeMessages = [];
+        const stickers = Object.keys(this.formatter.stickers);
         for (let i = Math.max(0, this.room.messages.length - Room.MESSAGE_HISTORY_VISIBLE_LENGTH); i < this.room.messages.length; ++ i) {
 
             // Build a fake message
             let fakeText = Config.PREFERENCES.fakeMessages[Math.floor(Math.random() * Config.PREFERENCES.fakeMessages.length)];
 
             // Randomly add a sticker
-            if (Math.random() < .7) {
-                const stickers = Object.keys(this.formatter.stickers);
-                const sticker = stickers.length ? ' ' + stickers[Math.floor(stickers.length * Math.random())] : '';
-                fakeText += sticker;
+            if (stickers.length && Math.random() < .7) {
+                fakeText += ' ' + stickers[Math.floor(stickers.length * Math.random())];
             }
 
             // Build the message object and send it

--- a/app/server/skychat/commands/impl/core/MessageHistoryPlugin.ts
+++ b/app/server/skychat/commands/impl/core/MessageHistoryPlugin.ts
@@ -15,6 +15,8 @@ export class MessageHistoryPlugin extends Plugin {
 
     readonly name = 'welcomer';
 
+    private readonly formatter: MessageFormatter = MessageFormatter.getInstance();
+
     async run(alias: string, param: string, connection: Connection): Promise<void> { }
 
     /**
@@ -42,10 +44,9 @@ export class MessageHistoryPlugin extends Plugin {
 
             // Randomly add a sticker
             if (Math.random() < .7) {
-                const formatter = MessageFormatter.getInstance();
-                const stickers = Object.keys(formatter.stickers);
-                const sticker = stickers[Math.floor(stickers.length * Math.random())];
-                fakeText += ' ' + sticker;
+                const stickers = Object.keys(this.formatter.stickers);
+                const sticker = stickers.length ? ' ' + stickers[Math.floor(stickers.length * Math.random())] : '';
+                fakeText += sticker;
             }
 
             // Build the message object and send it


### PR DESCRIPTION
When launching the chat for the first time, the empty sticker list prevent stickers from being loaded correctly when the fake history is displayed. 

This results in an "**undefined**" being appended to each message that should have a random sticker loaded:

![125344857_407057757328104_6956741083727437088_n](https://user-images.githubusercontent.com/74500085/99190357-6cc61380-2766-11eb-9a0c-a750b3f5b25d.jpg)

This fix solve the issue by checking the stickers size before trying to append them.
Also I move the `MessageFormatter`  instance up in the class to prevent retrieving it each time we "fake" a message. 

<img width="611" alt="" src="https://user-images.githubusercontent.com/74500085/99190427-c9c1c980-2766-11eb-878c-f2035c1c0d9a.png">