### PR TITLE
fix-halo-shadow Fix boxshadow offset

### DIFF
--- a/app/client/css/styles.scss
+++ b/app/client/css/styles.scss
@@ -94,6 +94,16 @@ body {
     }
 }
 
+.skychat-halo-preview {
+    border:1px solid white;
+    width:14px;
+    height:14px;
+    border-radius:50%;
+    background:transparent;
+    display:inline-block;
+    margin-right:4px;
+}
+
 .skychat-sticker {
     max-width: 80px;
     max-height: 80px;

--- a/app/client/css/styles.scss
+++ b/app/client/css/styles.scss
@@ -95,13 +95,13 @@ body {
 }
 
 .skychat-halo-preview {
-    border:1px solid white;
-    width:14px;
-    height:14px;
-    border-radius:50%;
-    background:transparent;
-    display:inline-block;
-    margin-right:4px;
+    border: 1px solid white;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: transparent;
+    display: inline-block;
+    margin-right: 4px;
 }
 
 .skychat-sticker {

--- a/app/server/skychat/commands/impl/customization/ShopPlugin.ts
+++ b/app/server/skychat/commands/impl/customization/ShopPlugin.ts
@@ -66,7 +66,9 @@ export class ShopPlugin extends Plugin {
             ],
             preview: (value, user) => `
                 <div style="color:${value};border-left: 4px solid ${value};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${user.data.plugins.halo ? '2px 2px 3px 2px ' + value : 'unset'}">&nbsp;</div>
+                    <div class="skychat-halo-preview" style="box-shadow:${user.data.plugins.halo ? '0px 0px 3px 2px ' + value : 'unset'}">
+                        &nbsp;
+                    </div>
                     <b>${user.username}</b>
                 </div>
             `,
@@ -79,7 +81,7 @@ export class ShopPlugin extends Plugin {
             ],
             preview: (value, user) => `
                 <div style="color:${user.data.plugins.color};border-left: 4px solid ${user.data.plugins.color};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${value ? '2px 2px 3px 2px ' + user.data.plugins.color : 'unset'}">
+                    <div class="skychat-halo-preview" style="box-shadow:${value ? '0px 0px 3px 2px ' + user.data.plugins.color : 'unset'}">
                         &nbsp;
                     </div>
                     <b>${user.username}</b>
@@ -153,7 +155,7 @@ export class ShopPlugin extends Plugin {
             })),
             preview: (value, user) => `
                 <div style="color:${user.data.plugins.color};border-left: 4px solid ${user.data.plugins.color};padding-left: 6px;">
-                    <div style="border:1px solid white;width:14px;height:14px;border-radius:50%;background:transparent;display:inline-block;margin-right:4px;box-shadow:${user.data.plugins.halo ? '2px 2px 3px 2px ' + user.data.plugins.color : 'unset'}">
+                    <div class="skychat-halo-preview" style="box-shadow:${user.data.plugins.halo ? '0px 0px 3px 2px ' + user.data.plugins.color : 'unset'}">
                         &nbsp;
                     </div>
                     <i class="material-icons md-14">${value}</i> <b>${user.username}</b>


### PR DESCRIPTION
`box-shadow: 2px 2px 3px 2px` used to be slightly off 
`box-shadow: 0px 0px 3px 2px` centers the halo 

Before:
<img width="433" alt="before-halo-fix" src="https://user-images.githubusercontent.com/74500085/115123533-bd63c600-9fbd-11eb-880c-8cf8e0ee9c28.png">
After:
<img width="429" alt="after-halo-fix" src="https://user-images.githubusercontent.com/74500085/115123531-bb9a0280-9fbd-11eb-8f09-319e13d5b8c1.png">
