### PR TITLE
Verbose logs & Fix crashes

### DIFF
--- a/app/server/plugins/security_extra/LogFuzzerPlugin.ts
+++ b/app/server/plugins/security_extra/LogFuzzerPlugin.ts
@@ -56,7 +56,9 @@ export class LogFuzzerPlugin extends GlobalPlugin {
     async tick(): Promise<void> {
         const limitTimestamp = Math.floor(new Date().getTime() - LogFuzzerPlugin.DURATION_BEFORE_FUZZ);
         Logging.info('Fuzzing messages before', new Date(limitTimestamp).toISOString());
-        const sqlQuery = SQL`select id, content from messages where id > ${this.storage.lastId} and date <= ${limitTimestamp} limit 5000`;
+        const sqlQuery = SQL`select id, content from messages where id > ${this.storage.lastId} and date <= ${new Date(
+            limitTimestamp,
+        ).toISOString()} limit 5000`;
         const messages: { content: string; id: number }[] = (await DatabaseHelper.db.query(sqlQuery)).rows;
         for (const { id, content } of messages) {
             const sqlQuery = SQL`update messages set content=${this.fuzzContent(content)} where id=${id}`;

--- a/app/server/plugins/security_extra/LogFuzzerPlugin.ts
+++ b/app/server/plugins/security_extra/LogFuzzerPlugin.ts
@@ -1,8 +1,9 @@
 import SQL from 'sql-template-strings';
-import { DatabaseHelper } from '../../skychat/DatabaseHelper.js';
-import { GlobalPlugin } from '../GlobalPlugin.js';
-import { RoomManager } from '../../skychat/RoomManager.js';
 import { Config } from '../../skychat/Config.js';
+import { DatabaseHelper } from '../../skychat/DatabaseHelper.js';
+import { Logging } from '../../skychat/Logging.js';
+import { RoomManager } from '../../skychat/RoomManager.js';
+import { GlobalPlugin } from '../GlobalPlugin.js';
 
 export class LogFuzzerPlugin extends GlobalPlugin {
     static readonly DURATION_BEFORE_FUZZ = Config.PREFERENCES.daysBeforeMessageFuzz * 24 * 60 * 60 * 1000;
@@ -54,6 +55,7 @@ export class LogFuzzerPlugin extends GlobalPlugin {
 
     async tick(): Promise<void> {
         const limitTimestamp = Math.floor(new Date().getTime() - LogFuzzerPlugin.DURATION_BEFORE_FUZZ);
+        Logging.info('Fuzzing messages before', new Date(limitTimestamp).toISOString());
         const sqlQuery = SQL`select id, content from messages where id > ${this.storage.lastId} and date <= ${limitTimestamp} limit 5000`;
         const messages: { content: string; id: number }[] = (await DatabaseHelper.db.query(sqlQuery)).rows;
         for (const { id, content } of messages) {

--- a/app/server/skychat/Room.ts
+++ b/app/server/skychat/Room.ts
@@ -9,6 +9,7 @@ import { Config } from './Config.js';
 import { Connection } from './Connection.js';
 import { DatabaseHelper } from './DatabaseHelper.js';
 import { IBroadcaster } from './IBroadcaster.js';
+import { Logging } from './Logging.js';
 import { Message, MessageConstructorOptions } from './Message.js';
 import { MessageController } from './MessageController.js';
 import { RoomManager } from './RoomManager.js';
@@ -224,6 +225,10 @@ export class Room implements IBroadcaster {
             this.pluginGroupNames = data.pluginGroupNames ?? this.pluginGroupNames;
             this.isPrivate = !!data.isPrivate;
             this.whitelist = data.whitelist;
+
+            if (this.isPrivate && this.whitelist.length === 0) {
+                Logging.warn(`Room ${this.id} is private but has no whitelist`);
+            }
         } catch (error) {
             console.error(`Could not load room ${this.id} data from disk: ${error}`);
             this.name = `Room ${this.id} (corrupted)`;

--- a/app/server/skychat/RoomManager.ts
+++ b/app/server/skychat/RoomManager.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { GlobalPlugin } from '../plugins/GlobalPlugin.js';
 import { Connection } from './Connection.js';
+import { Logging } from './Logging.js';
 import { Message } from './Message.js';
 import { PluginManager } from './PluginManager.js';
 import { Room } from './Room.js';
@@ -72,6 +73,7 @@ export class RoomManager {
 
         // Create rooms
         const rooms = data.rooms || [1];
+        Logging.info(`Lodaded ${rooms.length} rooms from storage`);
         this.rooms = rooms.map((id) => new Room(this, false, id));
     }
 


### PR DESCRIPTION
- Add debug logs to find crash cause
- Fix crashes

After investigation, crashes came from the `LogFuzzerPlugin` sending incorrect time values to Postgres (broken since the migration from SQLite to Postgres)