### PR TITLE
Increase max blacklist size from 10 to 150

### DIFF
--- a/app/server/plugins/core/global/BlacklistPlugin.ts
+++ b/app/server/plugins/core/global/BlacklistPlugin.ts
@@ -12,7 +12,7 @@ export type BlackListData = {
 export class BlacklistPlugin extends GlobalPlugin {
     static readonly defaultDataStorageValue: BlackListData = { users: [], guests: false };
 
-    static readonly MAX_BLACKLIST = 10;
+    static readonly MAX_BLACKLIST = 150;
 
     static readonly commandName = 'blacklist';
 


### PR DESCRIPTION
As per request of multiple big time international users from the skychat over the previous few weeks and an influx of children, I asked my best intern to increase the max number of blacklisted accounts from 10 to 150.