### PR TITLE
fix: focus message input after Quote/Edit from context menu

### DIFF
--- a/app/client/src/components/message/SingleMessage.vue
+++ b/app/client/src/components/message/SingleMessage.vue
@@ -3,6 +3,7 @@ import SkyContextMenu from '@/components/common/SkyContextMenu.vue';
 import SkyContextMenuItem from '@/components/common/SkyContextMenuItem.vue';
 import UserMiniAvatar from '@/components/user/UserMiniAvatar.vue';
 import { useIsBlacklisted } from '@/composables/useIsBlacklisted';
+import { useMessageComposer } from '@/composables/useMessageComposer';
 import { useUserRight } from '@/composables/useUserRight';
 import { useAppStore } from '@/stores/app';
 import { useClientStore } from '@/stores/client';
@@ -14,6 +15,7 @@ import MessageReactions from './MessageReactions.vue';
 const app = useAppStore();
 const client = useClientStore();
 const encryptionStore = useEncryptionStore();
+const composer = useMessageComposer();
 
 const COMPACT_QUOTES_MAX_LENGTH = 30;
 
@@ -202,12 +204,16 @@ const canDeleteMessage = computed(() => {
 const quoteMessage = () => {
     app.setMessage('@' + props.message.id + ' ');
     showActionMenu.value = false;
+    // Delay focus past Radix Vue's RAF-based focus restoration on context menu close
+    setTimeout(() => composer.value?.focus(), 0);
 };
 
 const editMessage = () => {
     if (!canEditMessage.value) return;
     app.setMessage('/edit ' + props.message.id + ' ' + props.message.content);
     showActionMenu.value = false;
+    // Delay focus past Radix Vue's RAF-based focus restoration on context menu close
+    setTimeout(() => composer.value?.focus(), 0);
 };
 
 const deleteMessage = () => {


### PR DESCRIPTION
## Problem

Right-clicking a message and selecting **Reply** or **Edit** from the context menu did not focus the message textarea.

Root cause: `SkyContextMenu` is built on Radix Vue's `ContextMenuRoot`, which restores focus to the trigger element after the menu closes — using `requestAnimationFrame`. This fired *after* the `app.newMessage` watcher in `NewMessageForm.vue` had already called `.focus()` on the textarea, effectively stealing focus back.

## Fix

In `quoteMessage` and `editMessage` inside `SingleMessage.vue`:
- Import and call `useMessageComposer()` to get the composer API (already registered by `NewMessageForm.vue`)
- After `app.setMessage(...)`, schedule `setTimeout(() => composer.value?.focus(), 0)`

`setTimeout(0)` is a macro task that runs **after** `requestAnimationFrame` callbacks, so our focus call wins reliably regardless of which trigger path is used (context menu or hover toolbar).

## Scope

- Only `SingleMessage.vue` is changed (4 lines: 1 import, 1 composable call, 2 setTimeout calls)
- No changes to the store, composable, or `NewMessageForm.vue`
- The hover toolbar Reply/Edit buttons already worked and continue to work (the `setTimeout(0)` is harmless for non-Radix paths)